### PR TITLE
archiver: load gh token from a file

### DIFF
--- a/repo_archiver.py
+++ b/repo_archiver.py
@@ -37,7 +37,7 @@ def parse_args():
     if args.repos is None and args.file is None:
         raise Exception("Must have either a list of repos, OR a file to read repos from")
     if args.token is None:
-        args.token = utils.get_pat()
+        args.token = utils.get_pat_from_file()
         if args.token is None:
             args.token = getpass('Please enter your GitHub token: ')
     return args

--- a/repo_archiver.py
+++ b/repo_archiver.py
@@ -53,11 +53,17 @@ def main():
     repolist = []
     if args.repos != []:
         repolist = args.repos
+    elif args.file:
+        try:
+            # Rip open the file, make a list
+            txtfile = open(args.file, 'r')
+            repolist = txtfile.readlines()
+            txtfile.close()
+        except:
+            print("Problem loading file!")
+            return
     else:
-        # Rip open the file, make a list
-        txtfile = open(args.file, 'r')
-        repolist = txtfile.readlines()
-        txtfile.close()
+        print("Please specify an org/repo or a file.")
 
     for orgrepo in repolist:
         try:

--- a/repo_archiver.py
+++ b/repo_archiver.py
@@ -14,6 +14,8 @@ from getpass import getpass
 from github3 import login
 from github3 import exceptions as gh_exceptions
 
+import utils
+
 def parse_args():
     """
     Go through the command line.
@@ -35,7 +37,9 @@ def parse_args():
     if args.repos is None and args.file is None:
         raise Exception("Must have either a list of repos, OR a file to read repos from")
     if args.token is None:
-        args.token = getpass('Please enter your GitHub token: ')
+        args.token = utils.get_pat()
+        if args.token is None:
+            args.token = getpass('Please enter your GitHub token: ')
     return args
 
 

--- a/repo_archiver.py
+++ b/repo_archiver.py
@@ -64,6 +64,7 @@ def main():
             return
     else:
         print("Please specify an org/repo or a file.")
+        return
 
     for orgrepo in repolist:
         try:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,21 @@
+import os
+import toml
+
+def get_pat(key_name='admin'):
+    home = os.path.expanduser("~")
+    config_file_name = ".gh_pat.toml"
+    if os.path.exists(config_file_name):
+        config_file = config_file_name
+    elif os.path.exists(os.path.join(home, config_file_name)):
+        config_file = os.path.join(home, config_file_name)
+    else:
+      # TODO: figure out more paths?
+      return None
+
+    try:
+      toml_blob = toml.load(config_file)
+      pat = toml_blob[key_name]
+      return pat
+    except Exception:
+      return None
+

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,6 @@ def get_pat(key_name='admin'):
     elif os.path.exists(os.path.join(home, config_file_name)):
         config_file = os.path.join(home, config_file_name)
     else:
-      # TODO: figure out more paths?
       return None
 
     try:

--- a/utils.py
+++ b/utils.py
@@ -17,6 +17,8 @@ def get_pat_from_file(key_name='admin'):
     else:
       return None
 
+    # TODO: check that file permissions are 600
+
     try:
       toml_blob = toml.load(config_file)
       pat = toml_blob[key_name]

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,13 @@
 import os
 import toml
 
-def get_pat(key_name='admin'):
+# pat file format:
+#
+# admin = "key1"
+# read-only = "key2"
+# key99 = "key99"
+#
+def get_pat_from_file(key_name='admin'):
     home = os.path.expanduser("~")
     config_file_name = ".gh_pat.toml"
     if os.path.exists(config_file_name):
@@ -17,4 +23,3 @@ def get_pat(key_name='admin'):
       return pat
     except Exception:
       return None
-


### PR DESCRIPTION
I'm lazy and security focused, so I don't want to have to paste the key every run and I don't want to have to put it on the command line. 

Load it from the same file I use for my cis_tools scripts.
- Degrades gracefully if you don't have the file (still prompts if not passed in as an arg).