### PR TITLE
repo_activity.py - adjusted how it looks at issues for activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ optional arguments:
 ## repo_activity.py
 
 ```
-usage: repo_activity.py [-h] [--pat-key PATKEY] [--file FILE] [-i] [repos ...]
+usage: repo_activity.py [-h] [--pat-key PATKEY] [--issues] [--file FILE] [-i] [repos ...]
 
-Gets a latest activity for a repo or list of repos
+Gets a latest activity for a repo or list of repos. Also checks wiki for activity, and can be told to check for issues activity.
 
 positional arguments:
   repos             list of repos to examine - or use --file for file base input
@@ -46,6 +46,7 @@ positional arguments:
 optional arguments:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --issues          Check the issues to set a date of activity if more recent than code
   --file FILE       File of 'owner/repo' names, 1 per line
   -i                Give visual output of that progress continues - useful for long runs redirected to a file
 ```

--- a/repo_activity.py
+++ b/repo_activity.py
@@ -37,7 +37,8 @@ def parse_args():
     """
 
     parser = argparse.ArgumentParser(
-        description="Gets a latest activity for a repo or list of repos"
+        description="Gets a latest activity for a repo or list of repos.  "
+        "Also checks wiki for activity, and can be told to check for issues activity."
     )
     parser.add_argument(
         "repos",
@@ -51,6 +52,11 @@ def parse_args():
         action="store",
         dest="patkey",
         help="key in .gh_pat.toml of the PAT to use",
+    )
+    parser.add_argument(
+        "--issues",
+        help="Check the issues to set a date of activity if more recent than code",
+        action="store_true",
     )
     parser.add_argument("--file", help="File of 'owner/repo' names, 1 per line", action="store")
     parser.add_argument(
@@ -70,80 +76,80 @@ def parse_args():
     return args
 
 
-def repo_activity(gh_sess, org, repo):  # pylint: disable=too-many-branches
-    """
-    Look at the repo, and return activity, with the date of their latest commit,
-        or no commit, over the last year
-    :param gh_sess: an initialized github session
-    :param org: the organization (or owner) name
-    :param repo: the repo name
-    :return: Status code of the commits iterator for retry purposes.
-    """
-    short_repo = gh_sess.repository(org, repo)
+# def repo_activity(gh_sess, org, repo):  # pylint: disable=too-many-branches
+#     """
+#     Look at the repo, and return activity, with the date of their latest commit,
+#         or no commit, over the last year
+#     :param gh_sess: an initialized github session
+#     :param org: the organization (or owner) name
+#     :param repo: the repo name
+#     :return: Status code of the commits iterator for retry purposes.
+#     """
+#     short_repo = gh_sess.repository(org, repo)
 
-    commitlist = {}
-    repo = short_repo.refresh()
-    topdate = 0
-    status_code = 200
-    commits = repo.commit_activity()
-    # Look through the last year of commit activity
-    # for each week, see if there's any commits
-    # if there is, and it's a more recent week than we have recorded, record it.
-    # (some returns from the commit_activity are out of order, hence
-    # we can't just look at the last active week and assume it's the most recent)
+#     commitlist = {}
+#     repo = short_repo.refresh()
+#     topdate = 0
+#     status_code = 200
+#     commits = repo.commit_activity()
+#     # Look through the last year of commit activity
+#     # for each week, see if there's any commits
+#     # if there is, and it's a more recent week than we have recorded, record it.
+#     # (some returns from the commit_activity are out of order, hence
+#     # we can't just look at the last active week and assume it's the most recent)
 
-    # Note: Repos with LOTS of activity (gecko-dev for one) are SO busy that commit
-    # stats for them will ALWAYS return a 202.  This is basically expected.
-    status_code = commits.last_status
-    try:
-        first = True
-        for week in commits:
-            # print(f'Result: {commits.last_status}, repo: {repo.name}', file = sys.stderr)
-            if first:
-                status_code = commits.last_status
-                # print(f'Result: {commits.last_status}, response: '
-                #       f'{commits.last_response}, repo: {repo.name}', file = sys.stderr)
-                if status_code == 202:
-                    return status_code
-                first = False
-            if week["total"] != 0:
-                if week["week"] > topdate:
-                    topdate = week["week"]
-        commitval = 0
-    except gh_exceptions.UnexpectedResponse:
-        # print(f'UNEXPECTED: Result: {commits.last_status}, response: '
-        #       f'{commits.last_response}, repo: {repo.name}', file = sys.stderr)
-        commitval = "Unexpected, possibly empty repo"
-    except gh_exceptions.NotFoundError:
-        # print(f'NOTFOUND: Result: {commits.last_status}, response: '
-        #       f'{commits.last_response}, repo: {repo.name}', file = sys.stderr)
-        commitval = "Unexpected, possibly temp repo"
-    finally:
-        status_code = commits.last_status
-    if commitval == 0 and topdate == 0:
-        # no commits found, update list as apropos
-        commitval = "None"
-    elif topdate != 0:
-        commitval = datetime.fromtimestamp(topdate)
-    commitlist[repo.name] = {
-        "created_at": repo.created_at,
-        "updated_at": repo.pushed_at,
-        "admin_update": repo.updated_at,
-        "last_commit": commitval,
-        "private": repo.private,
-        "archived": repo.archived,
-    }
+#     # Note: Repos with LOTS of activity (gecko-dev for one) are SO busy that commit
+#     # stats for them will ALWAYS return a 202.  This is basically expected.
+#     status_code = commits.last_status
+#     try:
+#         first = True
+#         for week in commits:
+#             # print(f'Result: {commits.last_status}, repo: {repo.name}', file = sys.stderr)
+#             if first:
+#                 status_code = commits.last_status
+#                 # print(f'Result: {commits.last_status}, response: '
+#                 #       f'{commits.last_response}, repo: {repo.name}', file = sys.stderr)
+#                 if status_code == 202:
+#                     return status_code
+#                 first = False
+#             if week["total"] != 0:
+#                 if week["week"] > topdate:
+#                     topdate = week["week"]
+#         commitval = 0
+#     except gh_exceptions.UnexpectedResponse:
+#         # print(f'UNEXPECTED: Result: {commits.last_status}, response: '
+#         #       f'{commits.last_response}, repo: {repo.name}', file = sys.stderr)
+#         commitval = "Unexpected, possibly empty repo"
+#     except gh_exceptions.NotFoundError:
+#         # print(f'NOTFOUND: Result: {commits.last_status}, response: '
+#         #       f'{commits.last_response}, repo: {repo.name}', file = sys.stderr)
+#         commitval = "Unexpected, possibly temp repo"
+#     finally:
+#         status_code = commits.last_status
+#     if commitval == 0 and topdate == 0:
+#         # no commits found, update list as apropos
+#         commitval = "None"
+#     elif topdate != 0:
+#         commitval = datetime.fromtimestamp(topdate)
+#     commitlist[repo.name] = {
+#         "created_at": repo.created_at,
+#         "updated_at": repo.pushed_at,
+#         "admin_update": repo.updated_at,
+#         "last_commit": commitval,
+#         "private": repo.private,
+#         "archived": repo.archived,
+#     }
 
-    for repo in commitlist:
-        print(
-            f"{repo},{commitlist[repo]['created_at']},"
-            f"{commitlist[repo]['updated_at']},"
-            f"{commitlist[repo]['admin_update']},"
-            f"{commitlist[repo]['last_commit']},"
-            f"{commitlist[repo]['private']},"
-            f"{commitlist[repo]['archived']}"
-        )
-    return status_code
+#     for repo in commitlist:
+#         print(
+#             f"{repo},{commitlist[repo]['created_at']},"
+#             f"{commitlist[repo]['updated_at']},"
+#             f"{commitlist[repo]['admin_update']},"
+#             f"{commitlist[repo]['last_commit']},"
+#             f"{commitlist[repo]['private']},"
+#             f"{commitlist[repo]['archived']}"
+#         )
+#     return status_code
 
 
 def get_wiki_date(reponame, token):
@@ -170,18 +176,20 @@ def get_wiki_date(reponame, token):
     return date
 
 
-def mini_repo_activity(gh_sess, org, repo, token):
+def mini_repo_activity(gh_sess, orgstr, repostr, token, issues, info):
     """
     Print out only the top level repo data without looking at the last years commits.
     :param gh_sess: an initialized GH session
-    :param org: string of the org
-    :param repo: string of the repo
+    :param orgstr: string of the org
+    :param repostr: string of the repo
     :param token: PAT needed for wiki analysis
+    :param issues: booolean about whether to look at issues
+    :param info: Should I output spinners, etc?
     :result: Prints out the data.
     """
     utils.check_rate_remain(gh_sess)
     try:
-        short_repo = gh_sess.repository(org, repo)
+        short_repo = gh_sess.repository(orgstr, repostr)
         repo = short_repo.refresh()
         # This gets us the commit date (pushed_at) but ignores the wiki
         pushed_date = repo.pushed_at
@@ -190,11 +198,38 @@ def mini_repo_activity(gh_sess, org, repo, token):
             wikidate = get_wiki_date(repo.full_name, token)
             if wikidate > pushed_date:
                 pushed_date = wikidate
-        print(
-            f"{org}/{repo.name},{repo.created_at.strftime('%Y-%m-%d')},{pushed_date.strftime('%Y-%m-%d')},{repo.updated_at.strftime('%Y-%m-%d')},{repo.private},{repo.archived}"
-        )
+
+        issue_whacky = ""
+        if issues:
+            issuecount = repo.open_issues_count
+            # If you have >1K issues open - SOMETHING's happening - set the activity to today
+            if issuecount > 1000:
+                pushed_date = datetime.now()
+                issue_whacky = "-MANY-ISSUES"
+            else:
+                issuelist = repo.issues(state="open")
+                for issue in issuelist:
+                    utils.check_rate_remain(gh_sess, update=info)
+                    if info:
+                        utils.spinner()
+                    issuedate = issue.updated_at
+                    if issuedate > pushed_date:
+                        pushed_date = issuedate
+
+        if issues:
+            print(
+                f"{orgstr}/{repo.name}{issue_whacky},{repo.created_at.strftime('%Y-%m-%d')},"
+                f"{pushed_date.strftime('%Y-%m-%d')},{repo.updated_at.strftime('%Y-%m-%d')},"
+                f"{repo.private},{repo.archived},{issuecount}"
+            )
+        else:
+            print(
+                f"{orgstr}/{repo.name}{issue_whacky},{repo.created_at.strftime('%Y-%m-%d')},"
+                f"{pushed_date.strftime('%Y-%m-%d')},{repo.updated_at.strftime('%Y-%m-%d')},"
+                f"{repo.private},{repo.archived}"
+            )
     except gh_exceptions.ConnectionError:
-        print(f"Timeout error, 'CLOUD' on repo {org}/{repo}")
+        print(f"Timeout error, 'CLOUD' on repo {orgstr}/{repostr}", file=sys.stderr)
 
 
 def main():
@@ -216,12 +251,17 @@ def main():
     gh_sess = login(token=args.token)
 
     # Print out the header.
-    print("Org/Repo, Created, Updated, Admin_update, Private, Archive_status")
+    if args.issues:
+        print("Org/Repo, Created, Updated, Admin_update, Private, Archive_status, Issue_Count")
+    else:
+        print("Org/Repo, Created, Updated, Admin_update, Private, Archive_status")
 
     for orgrepo in repolist:
         org = orgrepo.split("/")[0].strip()
         repo = orgrepo.split("/")[1].strip()
-        mini_repo_activity(gh_sess, org, repo, args.token)
+        # ignore ghsa repos --- they only lead to heartache when automated things interact
+        if repo.find("-ghsa-") == -1:
+            mini_repo_activity(gh_sess, org, repo, args.token, issues=args.issues, info=args.info)
         if args.info:
             utils.spinner()
 


### PR DESCRIPTION
ignore -ghsa- repos as they never have issues, and aren't really in use either.
if issues are examined, output the issue count.
if there are many issues, don't look at them all, set the activitydate to now, and add "-MANY-ISSUES" to the repo name.
added a spinner - if you're looking at 100 issues, there's no indication that it's DOING anything.