### PR TITLE
catch KeyError exception and warn

### DIFF
--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -112,9 +112,14 @@ def run_query(org, headers, url):
             raise Exception(
                 f"Query failed to run by returning code of" f" {request.status_code}. {query}"
             )
-        has_next_page = jsonified["data"]["organization"]["samlIdentityProvider"][
-            "externalIdentities"
-        ]["pageInfo"]["hasNextPage"]
+        try:
+            has_next_page = jsonified["data"]["organization"]["samlIdentityProvider"][
+                "externalIdentities"
+            ]["pageInfo"]["hasNextPage"]
+        except KeyError:
+            # missing scopes or PAT not authorized most likely
+            print(jsonified)
+            raise Exception("please inspect output above")
         cursor = jsonified["data"]["organization"]["samlIdentityProvider"]["externalIdentities"][
             "pageInfo"
         ]["endCursor"]


### PR DESCRIPTION
I was missing a scope on the PAT I was using, but it was hard to see what was wrong.

Catch the error and let user inspect the output for debugging.