### PR TITLE
org_samlreport: add comment header with structured data

### DIFF
--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -173,7 +173,7 @@ def main():
     now_dt = datetime.datetime.now()
     dt_string = now_dt.strftime("%Y%m%dT%H%M%S%z")
     structured_data_header = f"structured-data-header source=org_samlreport_output gh_org={args.org} datetime={dt_string}"
-    print("SAML,GH Login,%s" % structured_data_header, file=output)
+    print(f"SAML,GH Login,{structured_data_header}", file=output)
 
     for gh_name, ldap in user_mapping.items():
         print(f"{ldap},{gh_name}", file=output)

--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -168,6 +168,7 @@ def main():
     if args.output is not None:
         output = open(args.output, "w")
 
+    print("# org_samlreport_output gh_org:%s" % args.org)
     print("SAML,GH Login", file=output)
 
     for gh_name, ldap in user_mapping.items():

--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -172,10 +172,7 @@ def main():
     # add header column with structured data
     now_dt = datetime.datetime.now()
     dt_string = now_dt.strftime("%Y%m%dT%H%M%S%z")
-    structured_data_header = (
-        "structured-data-header source=org_samlreport_output gh_org=%s datetime=%s"
-        % (args.org, dt_string)
-    )
+    structured_data_header = f"structured-data-header source=org_samlreport_output gh_org={args.org} datetime={dt_string}"
     print("SAML,GH Login,%s" % structured_data_header, file=output)
 
     for gh_name, ldap in user_mapping.items():

--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -170,9 +170,9 @@ def main():
         output = open(args.output, "w")
 
     # add comment header with structured data
-    my_date = datetime.datetime.now()
-    the_dt = my_date.strftime("%Y%m%dT%H%M%S%z")
-    print("# org_samlreport_output gh_org:%s datetime:%s" % (args.org, the_dt))
+    now_dt = datetime.datetime.now()
+    dt_string = now_dt.strftime("%Y%m%dT%H%M%S%z")
+    print("# org_samlreport_output gh_org:%s datetime:%s" % (args.org, dt_string))
 
     print("SAML,GH Login", file=output)
 

--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -11,6 +11,7 @@ https://github.com/mozilla/github-org-scripts/blob/main/notebooks/UserSearchPy3.
 """
 
 import argparse
+import datetime
 import sys
 from getpass import getpass
 
@@ -168,7 +169,11 @@ def main():
     if args.output is not None:
         output = open(args.output, "w")
 
-    print("# org_samlreport_output gh_org:%s" % args.org)
+    # add comment header with structured data
+    my_date = datetime.datetime.now()
+    the_dt = my_date.strftime("%Y%m%dT%H%M%S%z")
+    print("# org_samlreport_output gh_org:%s datetime:%s" % (args.org, the_dt))
+
     print("SAML,GH Login", file=output)
 
     for gh_name, ldap in user_mapping.items():

--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -169,12 +169,14 @@ def main():
     if args.output is not None:
         output = open(args.output, "w")
 
-    # add comment header with structured data
+    # add header column with structured data
     now_dt = datetime.datetime.now()
     dt_string = now_dt.strftime("%Y%m%dT%H%M%S%z")
-    print("# org_samlreport_output gh_org:%s datetime:%s" % (args.org, dt_string))
-
-    print("SAML,GH Login", file=output)
+    structured_data_header = (
+        "structured-data-header source=org_samlreport_output gh_org=%s datetime=%s"
+        % (args.org, dt_string)
+    )
+    print("SAML,GH Login,%s" % structured_data_header, file=output)
 
     for gh_name, ldap in user_mapping.items():
         print(f"{ldap},{gh_name}", file=output)


### PR DESCRIPTION
My wrapper script for org_samlreport (in https://github.com/MoCo-GHE-Admin/cis_tools/pull/19) needs to know what org the output it receives is for. To avoid having to specify this, have org_samlreport add a comment header to the output with structured data (currently just the gh_org used and a timestamp).

new output:
```bash
# org_samlreport_output gh_org:mozilla datetime:20220524T162324
SAML,GH Login
None,21echoes
```