### PR TITLE
Add delay parameter to repo_close_issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ optional arguments:
 
 ## `repo_close_issues.py`
 ```
-usage: repo_close_issues.py [-h] [--close-pr] [--comment COMMENT] [--doit] [--token TOKEN] [--pat-key PATKEY] org repo
+usage: repo_close_issues.py [-h] [--close-pr] [--comment COMMENT] [--doit] [--token TOKEN] [--pat-key PATKEY] [--delay DELAY]
+                            org repo
 
 Close issues associated with the specified repo. Do not close PRs unless specified, and only do things if specified
 
@@ -307,6 +308,7 @@ optional arguments:
   --doit             Actually close things
   --token TOKEN      PAT to access github. Needs Write access to the repos
   --pat-key PATKEY   key in .gh_pat.toml of the PAT to use
+  --delay DELAY      seconds between close requests, to avoid secondary rate limits > 1
 ```
 
 ## `repo_unarchiver.py`

--- a/repo_close_issues.py
+++ b/repo_close_issues.py
@@ -41,6 +41,12 @@ def parse_args():
         dest="patkey",
         help="key in .gh_pat.toml of the PAT to use",
     )
+    parser.add_argument(
+        "--delay",
+        default=2,
+        type=float,
+        help="seconds between close requests, to avoid secondary rate limits > 1",
+    )
     args = parser.parse_args()
     args.token = utils.get_pat_from_file(args.patkey)
     if args.token is None:
@@ -95,8 +101,8 @@ def main():
                 close_issue(issue, args.comment)
                 print(" Closed.")
                 # Secondary Rate limit avoidance
-                #
-                time.sleep(1.1)
+                # https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
+                time.sleep(args.delay)
             else:
                 print(f'Issue found "{issue.title}", not closing due to dry run')
 


### PR DESCRIPTION
to better control avoiding secondary rate limits, increased default pause to 2 seconds and made it a parameter.