### PR TITLE
Hwine/issue69 dependency search wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,33 @@ optional arguments:
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
 ```
 
+## `gh_dependency_search.py`
+```
+usage: gh_dependency_search.py [-h] --package PACKAGE [--orgini]
+                               [--pat-key PATKEY] [-v] [-f] [-t TIME]
+                               [--language {Python,Javascript}]
+                               [orgs [orgs ...]]
+
+Get file search resuls for a dependency
+
+positional arguments:
+  orgs                  The org to work on
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --package PACKAGE     The package to search for.
+  --orgini              use "orglist.ini" with the "orgs" entry with a csv
+                        list of all orgs to check
+  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
+  -v                    Verbose - Print out that we're waiting for rate limit
+                        reasons
+  -f                    Print out file level responses rather than repo level
+  -t TIME               Time to sleep between searches, in seconds, should be
+                        10s or more
+  --language {Python,Javascript}
+                        Language to search for dependency, default is Python
+```
+
 ## `gh_file_search.py`
 ```
 usage: gh_file_search.py [-h] --query QUERY [--note-archive] [--orgini] [--pat-key PATKEY] [-v] [-f] [-t TIME] [orgs ...]

--- a/gh_dependency_search.py
+++ b/gh_dependency_search.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""
+Script to perform a search of supplied orgs, returning the repo list
+that return positives for a dependency of the specified language
+"""
+
+import argparse
+from getpass import getpass
+
+import utils
+from gh_file_search import do_search
+
+# data
+language_default = "Python"
+language_files = {
+    "Python": [
+        "requirements.txt",
+        "pyproject.toml",
+        "Pipfile",
+    ],
+    "Javascript": [
+        "project.json",
+    ],
+}
+
+
+def parse_arguments():
+    """
+    Look at the first arg and handoff to the arg parser for that specific
+    """
+    parser = argparse.ArgumentParser(description="Get file search resuls for a dependency")
+    parser.add_argument(
+        "--package", type=str, help="The package to search for.", action="store", required=True
+    )
+    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
+    parser.add_argument(
+        "--orgini",
+        help='use "orglist.ini" with the "orgs" ' "entry with a csv list of all orgs to check",
+        action="store_const",
+        const="orglist.ini",
+    )
+    parser.add_argument(
+        "--pat-key",
+        default="admin",
+        action="store",
+        dest="patkey",
+        help="key in .gh_pat.toml of the PAT to use",
+    )
+    parser.add_argument(
+        "-v",
+        dest="verbose",
+        help="Verbose - Print out that we're waiting for rate limit reasons",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "-f",
+        dest="print_file",
+        help="Print out file level responses rather than repo level",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-t",
+        dest="time",
+        default=10,
+        type=int,
+        help="Time to sleep between searches, in seconds, should be 10s or more",
+    )
+    parser.add_argument(
+        "--language",
+        choices=language_files.keys(),
+        default=language_default,
+        help=f"Language to search for dependency, default is {language_default}",
+    )
+    args = parser.parse_args()
+    if args.orgs == [] and args.orgini is None:
+        raise Exception("You must specify either an org or an orgini")
+    args.token = utils.get_pat_from_file(args.patkey)
+    if args.token is None:
+        args.token = getpass("Please enter your GitHub token: ")
+    return args
+
+
+def main():
+    """
+    Taking in the query and list of orgs, run the search,
+    print out the org name and the list of repos affected.
+    """
+    args = parse_arguments()
+
+    # just call gh_file_search.py with the defaults
+    for file in language_files[args.language]:
+        new_query = f"filename:{file} {args.package}"
+        # rudely inject the query option and archive status
+        args.query = new_query
+        args.note_archive = True
+        print(f"Searching for: {new_query}")
+        do_search(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/gh_file_search.py
+++ b/gh_file_search.py
@@ -85,6 +85,10 @@ def main():
     print out the org name and the list of repos affected.
     """
     args = parse_arguments()
+    do_search(args)
+
+
+def do_search(args):
     # Read in the config if there is one
     orglist = []
     if args.orgini is not None:


### PR DESCRIPTION
As noted in #69, there's a better way to get this information. However, I'm still submitting this as:
- it works today
- the refactor of `gh_file_search.py` (first commit) may be a useful pattern