### PR TITLE
Debug/UI tweaks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "cSpell.words": [
+        "fullrepo",
+        "orgini",
+        "orglist",
+        "ORGNAME",
+        "patkey",
+        "sess",
+        "vistext"
+    ]
+}

--- a/gh_file_search.py
+++ b/gh_file_search.py
@@ -144,7 +144,7 @@ def do_search(args):
             utils.spinner(org, end_spinner=True)
             if args.print_file and files:
                 for line in files:
-                    print("fred", line)
+                    print(line)
             elif repos:
                 print("\n".join(repos))
 

--- a/github_scripts/utils.py
+++ b/github_scripts/utils.py
@@ -146,15 +146,26 @@ def _create_char_spinner():
 
 
 _spinner = _create_char_spinner()
+_last_label = None
 
 
-def spinner(label=""):
+def spinner(label="", end_spinner=False):
     """
     Prints label with a spinner.
     When called repeatedly from inside a loop this prints
     a one line CLI spinner.
     """
+    global _last_label
+    if _last_label != label:
+        if _last_label is not None:
+            sys.stderr.write("\n")
+        _last_label = label
     sys.stderr.write("\r%s %s" % (label, next(_spinner)))
+    if end_spinner:
+        # we're done with the spinner, ensure that further output goes
+        # to a new line
+        sys.stderr.write("\n")
+        _last_label = None
     sys.stderr.flush()
 
 


### PR DESCRIPTION
My bad -- this got mixed -- holler if you want it teased apart.

There is a real bug fix buried in the 2nd commit: when reporting file names, the name was repeated. E.g. for `docker/Dockerfile` was reported as `docker/Dockerfile/Dockerfile`

This stuff got me far enough to file a real bug.  First commit is vs-code linting -- happy to keep that local if y'all don't want to commit.

Second commit is meat. Commit message:

    Clean up output

    A few changes to make debugging easier
    - all messages use stderr, so stdout only has ouptut
    - add org name to spinner as added context when checking 50 orgs
    - got rid of some blank lines
    - use 'raise SystemExit' to avoid tracebacks
    - cleaned up some type warnings by aborting if Null values returned from
      github3 routines