### PR TITLE
Setup a custom argparser with the usual suspects - and use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ Starts with:
 
 ## `gh_api_remain.py`
 ```
-usage: gh_api_remain.py [-h] [--pat-key PATKEY]
+usage: gh_api_remain.py [-h] [--pat-key PATKEY] [--token TOKEN]
 
 Print out the remaining API limits, and the time of the reset
 
 optional arguments:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
 ```
 
 ## `gh_dependency_search.py`
 ```
-usage: gh_dependency_search.py [-h] --package PACKAGE [--orgini]
-                               [--pat-key PATKEY] [-v] [-f] [-t TIME]
+usage: gh_dependency_search.py [-h] [--pat-key PATKEY] [--token TOKEN] --package PACKAGE [--orgini] [-v] [-f] [-t TIME]
                                [--language {Python,Javascript}]
-                               [orgs [orgs ...]]
+                               [orgs ...]
 
 Get file search resuls for a dependency
 
@@ -36,24 +36,23 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --package PACKAGE     The package to search for.
-  --orgini              use "orglist.ini" with the "orgs" entry with a csv
-                        list of all orgs to check
   --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
-  -v                    Verbose - Print out that we're waiting for rate limit
-                        reasons
+  --token TOKEN         use this PAT to access resources
+  --package PACKAGE     The package to search for.
+  --orgini              use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
+  -v                    Verbose - Print out that we're waiting for rate limit reasons
   -f                    Print out file level responses rather than repo level
-  -t TIME               Time to sleep between searches, in seconds, should be
-                        10s or more
+  -t TIME               Time to sleep between searches, in seconds, should be 10s or more
   --language {Python,Javascript}
                         Language to search for dependency, default is Python
 ```
 
 ## `gh_file_search.py`
 ```
-usage: gh_file_search.py [-h] --query QUERY [--note-archive] [--orgini] [--pat-key PATKEY] [-v] [-f] [-t TIME] [orgs ...]
+usage: gh_file_search.py [-h] [--pat-key PATKEY] [--token TOKEN] --query QUERY [--note-archive] [--orgini] [-v] [-f] [-t TIME]
+                         [orgs ...]
 
-Get file search resuls for an org, returning repo list. e.g. if you want 'org:<ORGNAME> filename:<FILENAME> <CONTENTS>', then you
+Get file search results for an org, returning repo list. e.g. if you want 'org:<ORGNAME> filename:<FILENAME> <CONTENTS>', then you
 just need 'filename:<FILENAME> <CONTENTS>' and then list the orgs to apply it to. Note: There's a pause of ~10 seconds between org
 searches due to GitHub rate limits - add a -v if you want notice printed that it's waiting
 
@@ -62,11 +61,12 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --query QUERY     The query to run, without orgs
   --note-archive    if specified, will add archival status of the repo to the output, this will slow things down and use more API
                     calls
   --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
-  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
   -v                Verbose - Print out that we're waiting for rate limit reasons
   -f                Print out file level responses rather than repo level
   -t TIME           Time to sleep between searches, in seconds, should be 10s or more
@@ -74,7 +74,7 @@ optional arguments:
 
 ## `gh_org_licenses.py`
 ```
-usage: gh_org_licenses.py [-h] [--pending] [--orgini] [--pat-key PATKEY] [orgs ...]
+usage: gh_org_licenses.py [-h] [--pat-key PATKEY] [--token TOKEN] [--pending] [--orgini] [orgs ...]
 
 Provided a list of orgs, output how many GHE licenses are required.
 
@@ -83,14 +83,15 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --pending         Include Pending requests?
   --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
-  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
 ```
 
-## gh_org_repo_perms.py
+## `gh_org_repo_perms.py`
 ```
-usage: gh_org_repo_perms.py [-h] [--pat-key PATKEY] [--user USER | --repo REPO] [-i] org
+usage: gh_org_repo_perms.py [-h] [--pat-key PATKEY] [--token TOKEN] [--user USER | --repo REPO] org
 
 Depending on args, dump all repos in an org, repos for a user or users for a repo, and their user permissions, defaults to all repos
 and users in an org.
@@ -101,6 +102,7 @@ positional arguments:
 optional arguments:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --user USER       Single user to examine in the org
   --repo REPO       Single repo to examine in the org
 ```
@@ -122,7 +124,7 @@ optional arguments:
 
 ## `gh_user_moderation.py`
 ```
-usage: gh_user_moderation.py [-h] [--block] [--orgini] [--pat-key PATKEY] username [orgs ...]
+usage: gh_user_moderation.py [-h] [--pat-key PATKEY] [--token TOKEN] [--block] [--orgini] username [orgs ...]
 
 Look at orgs, and either block or unblock the specified username
 
@@ -132,14 +134,15 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --block           should we block the user - default is unblock
   --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
-  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
 ```
 
 ## `gh_user_perms.py`
 ```
-usage: gh_user_perms.py [-h] [--no-archive] [--pat-key PATKEY] [--repo REPO] user org
+usage: gh_user_perms.py [-h] [--pat-key PATKEY] [--token TOKEN] [--no-archive] [--repo REPO] user org
 
 Report on a user's permissions in an org.
 
@@ -149,14 +152,16 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
-  --no-archive      Omit archived repos from the response
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
+  --no-archive      Omit archived repos from the response
   --repo REPO       Single repo to examine in the org
 ```
 
 ## `org_audit_licensefile.py`
 ```
-usage: org_audit_licensefile.py [-h] [--archived] [--type {public,private,all}] [--include-URL] [--orgini] [--pat-key PATKEY]
+usage: org_audit_licensefile.py [-h] [--pat-key PATKEY] [--token TOKEN] [--archived] [--type {public,private,all}] [--include-URL]
+                                [--orgini]
                                 [orgs ...]
 
 given the org, look through all repos of type, and archive status and report on github detected licenses.
@@ -166,17 +171,18 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
+  --token TOKEN         use this PAT to access resources
   --archived            Include archived repos. Default is unarchived only.
   --type {public,private,all}
                         Type of repo: private, public, all (Default).
   --include-URL         Include the URL to the repo as a help for people analyzing things
   --orgini              use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
-  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
 ```
 
 ## `org_comms_team.py`
 ```
-usage: org_comms_team.py [-h] [--team-name TEAM_NAME] [--pat-key PATKEY] [--users USERS [USERS ...]] [--remove] org
+usage: org_comms_team.py [-h] [--pat-key PATKEY] [--token TOKEN] [--team-name TEAM_NAME] [--users USERS [USERS ...]] [--remove] org
 
 Go into an org, create a team named for the --team-name and add all members to it, OR if --users is specified - add that list of
 users. Specify --remove to invert the operation
@@ -186,50 +192,18 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
+  --token TOKEN         use this PAT to access resources
   --team-name TEAM_NAME
                         name of the team to create, defaults to 'everybody-temp-comms'
-  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
   --users USERS [USERS ...]
                         List of users to add to the team
   --remove              Remove the specified users from the team rather than add
 ```
 
-## `org_repos.py`
-
-```
-usage: org_repos.py [-h] [--pat-key PATKEY] [--without-org] [--archived] [--type {public,private,all}] org
-
-Gets a list of Repos for an Org.
-
-positional arguments:
-  org                   The GH org to query
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
-  --without-org         Include the org in the name, 'org/repo-name'
-  --archived            Include archived repos. Default is unarchived only.
-  --type {public,private,all}
-                        Type of repo: private, public, all.
-```
-
-## `org_secret_alerts.py`
-```
-usage: org_secret_alerts.py [-h] [--pat-key PATKEY] org
-
-examine org for open security alerts from secret scanning, outputing csv data to pursue the alerts
-
-positional arguments:
-  org               The org that the repos are in
-
-optional arguments:
-  -h, --help        show this help message and exit
-  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
-```
-
 ## `org_owners.py`
 ```
-usage: org_owners.py [-h] [--orgini] [--pat-key PATKEY] [orgs ...]
+usage: org_owners.py [-h] [--pat-key PATKEY] [--token TOKEN] [--orgini] [orgs ...]
 
 Look at orgs, and get the list of owners
 
@@ -238,13 +212,14 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
-  --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
+  --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
 ```
 
 ## `org_remove_user.py`
 ```
-usage: org_remove_user.py [-h] [--pat-key PATKEY] [--orgfile] [--do-it] username [orgs ...]
+usage: org_remove_user.py [-h] [--pat-key PATKEY] [--token TOKEN] [--orgfile] [--do-it] username [orgs ...]
 
 Given a username - go through all orgs in the orglist.ini file and see what they need to be removed from
 
@@ -255,13 +230,33 @@ positional arguments:
 optional arguments:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --orgfile         use an ini file with the "orgs" entry with a csv list of all orgs to check, defaults to "orglist.ini"
   --do-it           Actually do the removal - Otherwise just report on what you found
 ```
 
+## `org_repos.py`
+```
+usage: org_repos.py [-h] [--pat-key PATKEY] [--token TOKEN] [--without-org] [--archived] [--type {public,private,all}] org
+
+Gets a list of Repos for an Org.
+
+positional arguments:
+  org                   The GH org to query
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
+  --token TOKEN         use this PAT to access resources
+  --without-org         Include the org in the name, 'org/repo-name'
+  --archived            Include archived repos. Default is unarchived only.
+  --type {public,private,all}
+                        Type of repo: private, public, all.
+```
+
 ## `org_samlreport.py`
 ```
-usage: org_samlreport.py [-h] [--url URL] [--pat-key PATKEY] [-f OUTPUT] org
+usage: org_samlreport.py [-h] [--pat-key PATKEY] [--token TOKEN] [--url URL] [-f OUTPUT] org
 
 Get SAML account mappings out of a GitHub org
 
@@ -270,14 +265,30 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
-  --url URL         the graphql URL
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
+  --url URL         the graphql URL
   -f OUTPUT         File to store CSV to
+```
+
+## `org_secret_alerts.py`
+```
+usage: org_secret_alerts.py [-h] [--pat-key PATKEY] [--token TOKEN] org
+
+examine org for open security alerts from secret scanning, outputting csv data to pursue the alerts
+
+positional arguments:
+  org               The org that the repos are in
+
+optional arguments:
+  -h, --help        show this help message and exit
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
 ```
 
 ## `org_teams.py`
 ```
-usage: org_teams.py [-h] [--pat-key PATKEY] [--team TEAM] [--unmark] org
+usage: org_teams.py [-h] [--pat-key PATKEY] [--token TOKEN] [--team TEAM] [--unmark] org
 
 Gets a list of teams and their users for an Org. Users with '*' are maintainers of the team, reports using the team-slug
 
@@ -287,14 +298,34 @@ positional arguments:
 optional arguments:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --team TEAM       The team slug to dump - if specified will ONLY use that team. (slug, NOT name)
   --unmark          Do not mark maintainers in the list
 ```
 
-## `repo_activity.py`
-
+## `repo_active_users.py`
 ```
-usage: repo_activity.py [-h] [--pat-key PATKEY] [--issues] [--file FILE] [-i] [repos ...]
+usage: repo_active_users.py [-h] [--pat-key PATKEY] [--token TOKEN] [--days DAYS] [--author] [--debug] org repos [repos ...]
+
+Gets a list of active users for a list of reposAlso checks wiki for activity, and can be told to check for issues activity.
+
+positional arguments:
+  org               The organization that the repos belong to
+  repos             list of repos to examine - or use --file for file base input
+
+optional arguments:
+  -h, --help        show this help message and exit
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
+  --days DAYS       How many days back to look, default, 30
+  --author          Use the author rather than committer email, if you're concerned about people with permissions, committer is what
+                    you want
+  --debug
+```
+
+## `repo_activity.py`
+```
+usage: repo_activity.py [-h] [--pat-key PATKEY] [--token TOKEN] [--issues] [--file FILE] [-i] [repos ...]
 
 Gets a latest activity for a repo or list of repos. Also checks wiki for activity, and can be told to check for issues activity.
 
@@ -304,6 +335,7 @@ positional arguments:
 optional arguments:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --issues          Check the issues to set a date of activity if more recent than code
   --file FILE       File of 'owner/repo' names, 1 per line
   -i                Give visual output of that progress continues - useful for long runs redirected to a file
@@ -311,7 +343,7 @@ optional arguments:
 
 ## `repo_add_perms.py`
 ```
-usage: repo_add_perms.py [-h] --perm PERM --org ORG --repos REPOS [REPOS ...] [--apihost APIHOST] [--pat-key PATKEY]
+usage: repo_add_perms.py [-h] [--pat-key PATKEY] [--token TOKEN] --perm PERM --org ORG --repos REPOS [REPOS ...] [--apihost APIHOST]
                          {team,member} name
 
 invite member or team to specified repos at specified level. If adding a user, if the user is a member, adds the member, else invites
@@ -323,18 +355,19 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
+  --token TOKEN         use this PAT to access resources
   --perm PERM           String of the role name, defaults are 'read', 'write', 'triage', 'maintain', 'admin' - but others can be set
                         by the repo admin
   --org ORG             Organization/owner that the repos belong to
   --repos REPOS [REPOS ...]
                         list of repo names
   --apihost APIHOST     API host to connect to - default api.github.com
-  --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
 ```
 
 ## `repo_archiver.py`
 ```
-usage: repo_archiver.py [-h] [--token TOKEN] [--pat-key PATKEY] [--inactive] [--custom CUSTOM] [--file FILE] [--force] [--pause] [-q]
+usage: repo_archiver.py [-h] [--pat-key PATKEY] [--token TOKEN] [--inactive] [--custom CUSTOM] [--file FILE] [--force] [--pause] [-q]
                         [repos ...]
 
 Archive the specified repo, labelling and then closing out issues and PRs, per GitHub best practices. Closed issues/PRs, and
@@ -345,8 +378,8 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
-  --token TOKEN     PAT to access github. Needs Write access to the repos
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   --inactive        Change the 'abandoned' and 'deprecated' wording to 'inactive'
   --custom CUSTOM   Custom text to add to issue/PR label, and description, less than 36 char long
   --file FILE       File with "owner/repo" one per line to archive
@@ -357,7 +390,7 @@ optional arguments:
 
 ## `repo_close_issues.py`
 ```
-usage: repo_close_issues.py [-h] [--close-pr] [--comment COMMENT] [--doit] [--token TOKEN] [--pat-key PATKEY] [--delay DELAY]
+usage: repo_close_issues.py [-h] [--pat-key PATKEY] [--token TOKEN] [--close-pr] [--comment COMMENT] [--doit] [--delay DELAY]
                             org repo
 
 Close issues associated with the specified repo. Do not close PRs unless specified, and only do things if specified
@@ -368,17 +401,17 @@ positional arguments:
 
 optional arguments:
   -h, --help         show this help message and exit
+  --pat-key PATKEY   key in .gh_pat.toml of the PAT to use
+  --token TOKEN      use this PAT to access resources
   --close-pr         Close the PRs too?
   --comment COMMENT  A comment to close the issue with
   --doit             Actually close things
-  --token TOKEN      PAT to access github. Needs Write access to the repos
-  --pat-key PATKEY   key in .gh_pat.toml of the PAT to use
   --delay DELAY      seconds between close requests, to avoid secondary rate limits > 1
 ```
 
 ## `repo_unarchiver.py`
 ```
-usage: repo_unarchiver.py [-h] [--token TOKEN] [--pat-key PATKEY] [-q] repo
+usage: repo_unarchiver.py [-h] [--pat-key PATKEY] [--token TOKEN] [-q] repo
 
 Reverse archival closing of issues of the specified repo, Note, repo MUST be manually unarchived before this script
 
@@ -387,11 +420,10 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
-  --token TOKEN     PAT to access github. Needs Write access to the repos
-  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use, default: 'admin'
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
   -q                DO NOT print, or request confirmations
 ```
-
 # Supporting files
 
 ## `orglist.ini`

--- a/gh_api_remain.py
+++ b/gh_api_remain.py
@@ -3,9 +3,7 @@
 Check remaining API calls, and time of next reset
 """
 
-import argparse
 from datetime import datetime
-from getpass import getpass
 
 from github3 import login
 
@@ -17,20 +15,10 @@ def parse_args():
     Parse the args - need either the username adn token, or the config to exist
     return the parsed args.
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Print out the remaining API limits, and the time of the reset"
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/gh_dependency_search.py
+++ b/gh_dependency_search.py
@@ -4,9 +4,6 @@ Script to perform a search of supplied orgs, returning the repo list
 that return positives for a dependency of the specified language
 """
 
-import argparse
-from getpass import getpass
-
 from gh_file_search import do_search
 from github_scripts import utils
 
@@ -28,7 +25,7 @@ def parse_arguments():
     """
     Look at the first arg and handoff to the arg parser for that specific
     """
-    parser = argparse.ArgumentParser(description="Get file search resuls for a dependency")
+    parser = utils.GH_ArgParser(description="Get file search resuls for a dependency")
     parser.add_argument(
         "--package", type=str, help="The package to search for.", action="store", required=True
     )
@@ -38,13 +35,6 @@ def parse_arguments():
         help='use "orglist.ini" with the "orgs" ' "entry with a csv list of all orgs to check",
         action="store_const",
         const="orglist.ini",
-    )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
     )
     parser.add_argument(
         "-v",
@@ -75,9 +65,6 @@ def parse_arguments():
     args = parser.parse_args()
     if args.orgs == [] and args.orgini is None:
         raise Exception("You must specify either an org or an orgini")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/gh_file_search.py
+++ b/gh_file_search.py
@@ -3,10 +3,8 @@
 Script to perform a search of supplied orgs, returning the repo list that return positives
 """
 
-import argparse
 import configparser
 import sys
-from getpass import getpass
 from time import sleep
 
 from github3 import exceptions as gh_exceptions
@@ -19,7 +17,7 @@ def parse_arguments():
     """
     Look at the first arg and handoff to the arg parser for that specific
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Get file search results for an org, returning repo list.  "
         "e.g. if you want 'org:<ORGNAME> filename:<FILENAME> <CONTENTS>', "
         "then you just need 'filename:<FILENAME> <CONTENTS>' "
@@ -44,13 +42,6 @@ def parse_arguments():
         const="orglist.ini",
     )
     parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
-    parser.add_argument(
         "-v",
         dest="verbose",
         help="Verbose - Print out that we're waiting for rate limit reasons",
@@ -73,9 +64,6 @@ def parse_arguments():
     args = parser.parse_args()
     if args.orgs == [] and args.orgini is None:
         raise SystemExit("You must specify either an org or an orgini")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/gh_org_licenses.py
+++ b/gh_org_licenses.py
@@ -8,9 +8,7 @@ Outside collaborators with ANY access (even just read) to a private repo take a 
 
 """
 
-import argparse
 import configparser
-from getpass import getpass
 
 from github3 import exceptions as gh_exceptions
 from github3 import login
@@ -23,7 +21,7 @@ def parse_arguments():
     Get a list of orgs (either in CLI or in INI file)
     Get the PAT (either via command line or toml file)
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Provided a list of orgs, output how many GHE licenses are required."
     )
     parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
@@ -34,19 +32,9 @@ def parse_arguments():
         action="store_const",
         const="orglist.ini",
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     args = parser.parse_args()
     if args.orgs == [] and args.orgini is None:
         raise Exception("You must specify either an org or an orgini")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/gh_org_repo_perms.py
+++ b/gh_org_repo_perms.py
@@ -9,10 +9,8 @@ So there's no indication here if the perm is to the user or a team they
 belong to.
 """
 
-import argparse
 import os
 import sys
-from getpass import getpass
 
 import alive_progress
 from github3 import login
@@ -26,24 +24,14 @@ def parse_args():
     :return: Returns the parsed CLI datastructures.
     """
 
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Depending on args, dump all repos in an org, repos for a user or users for a repo, and their user permissions, defaults to all repos and users in an org."
     )
     parser.add_argument("org", help="The org to examine", action="store")
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     analyse_group = parser.add_mutually_exclusive_group()
     analyse_group.add_argument("--user", help="Single user to examine in the org")
     analyse_group.add_argument("--repo", help="Single repo to examine in the org")
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/gh_user_moderation.py
+++ b/gh_user_moderation.py
@@ -3,9 +3,7 @@
 Script to manually poke the blocks/unblocks for orgs.
 """
 
-import argparse
 import configparser
-from getpass import getpass
 
 import requests
 
@@ -16,7 +14,7 @@ def parse_arguments():
     """
     Look at the first arg and handoff to the arg parser for that specific
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Look at orgs, and either block or " "unblock the specified username"
     )
     parser.add_argument("username", type=str, help="The GH user name to block/unblock")
@@ -30,19 +28,9 @@ def parse_arguments():
         action="store_const",
         const="orglist.ini",
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     args = parser.parse_args()
     if args.orgs == [] and args.orgini is None:
         raise Exception("You must specify either an org or an orgini")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/gh_user_perms.py
+++ b/gh_user_perms.py
@@ -7,10 +7,8 @@ So there's no indication here if the perm is to the user or a team they
 belong to.
 """
 
-import argparse
 import os
 import sys
-from getpass import getpass
 
 import alive_progress
 from github3 import login
@@ -24,7 +22,7 @@ def parse_args():
     :return: Returns the parsed CLI datastructures.
     """
 
-    parser = argparse.ArgumentParser(description="Report on a user's permissions in an org.")
+    parser = utils.GH_ArgParser(description="Report on a user's permissions in an org.")
     parser.add_argument("user", help="Single user to examine in the org")
     parser.add_argument("org", help="The org to examine")
     parser.add_argument(
@@ -33,20 +31,10 @@ def parse_args():
         action="store_true",
         dest="omit_archive",
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     # TODO: add verbose to show the raw datastructure?
     parser.add_argument("--repo", help="Single repo to examine in the org")
     args = parser.parse_args()
 
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/github_scripts/utils.py
+++ b/github_scripts/utils.py
@@ -1,9 +1,11 @@
 """
 Helper file for code reuse throughout the github-scripts
 """
+import argparse
 import os
 import sys
 from datetime import datetime
+from getpass import getpass
 from time import sleep
 
 import alive_progress
@@ -98,6 +100,33 @@ class GHPermsQuery:
                     )
                 bar()
         return userlist
+
+
+class GH_ArgParser(argparse.ArgumentParser):
+    """
+    Used to have some "Normal" things made standard across all github-scripts - token management being the first.
+    """
+
+    def __init__(self, *args, **kwargs):
+        argparse.ArgumentParser.__init__(self, *args, **kwargs)
+        self.add_argument(
+            "--pat-key",
+            default="admin",
+            action="store",
+            dest="patkey",
+            help="key in .gh_pat.toml of the PAT to use",
+        )
+        self.add_argument("--token", help="use this PAT to access resources")
+
+    def parse_args(self):
+        args = super().parse_args()
+        file_token = get_pat_from_file(args.patkey)
+        if args.token is None:
+            if file_token is None:
+                args.token = getpass("Please enter your GitHub token: ")
+            else:
+                args.token = file_token
+        return args
 
 
 def get_pat_from_file(key_name="admin"):

--- a/org_audit_licensefile.py
+++ b/org_audit_licensefile.py
@@ -3,11 +3,9 @@
 Script to perform a search of supplied orgs, and return the list of detected repo licenses.
 """
 
-import argparse
 import configparser
 import sys
 from datetime import datetime
-from getpass import getpass
 
 from github3 import exceptions as gh_exceptions
 from github3 import login
@@ -19,7 +17,7 @@ def parse_arguments():
     """
     Look at the first arg and handoff to the arg parser for that specific
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="given the org, look through all repos of type, and archive status and report on github detected licenses."
     )
     parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
@@ -47,19 +45,9 @@ def parse_arguments():
         action="store_const",
         const="orglist.ini",
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     args = parser.parse_args()
     if args.orgs == [] and args.orgini is None:
         raise Exception("You must specify either an org or an orgini")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/org_comms_team.py
+++ b/org_comms_team.py
@@ -7,9 +7,6 @@ Mainly used prior to SAML enable/enforcement - so there's chances that
 SAML will be in a splitbrain mode
 """
 
-import argparse
-from getpass import getpass
-
 from github3 import exceptions as gh_exceptions
 from github3 import login
 
@@ -22,7 +19,7 @@ def parse_args():
     If no token is specified prompt for it.
     :return: Returns the parsed CLI datastructures.
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Go into an org, create a team named for the --team-name and add all members to it, OR if --users is specified - add that list of users.  Specify --remove to invert the operation"
     )
     parser.add_argument("org", help="organization to do this to", action="store")
@@ -33,13 +30,6 @@ def parse_args():
         action="store",
         default="everybody-temp-comms",
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     parser.add_argument("--users", nargs="+", help="List of users to add to the team")
     parser.add_argument(
         "--remove",
@@ -47,9 +37,6 @@ def parse_args():
         action="store_true",
     )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/org_owners.py
+++ b/org_owners.py
@@ -3,9 +3,7 @@
 Script to generate a list of owners of all orgs - with the orgs they own.
 """
 
-import argparse
 import configparser
-from getpass import getpass
 
 from github3 import login
 
@@ -16,7 +14,7 @@ def parse_arguments():
     """
     Look at the first arg and handoff to the arg parser for that specific
     """
-    parser = argparse.ArgumentParser(description="Look at orgs, and get the list of owners")
+    parser = utils.GH_ArgParser(description="Look at orgs, and get the list of owners")
     parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
     parser.add_argument(
         "--orgini",
@@ -24,19 +22,9 @@ def parse_arguments():
         action="store_const",
         const="orglist.ini",
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     args = parser.parse_args()
     if args.orgs == [] and args.orgini is None:
         raise Exception("You must specify either an org or an orgini")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/org_remove_user.py
+++ b/org_remove_user.py
@@ -7,14 +7,14 @@ and then go through the repos, and remove them as outside collaborators.
 
 # TODO: Look at making it able to take multiple usernames on the command line
 
-import argparse
 import configparser
-from getpass import getpass
 
 # from github3 import exceptions as gh_exceptions
 from github3 import login
 
 from github_scripts import utils
+
+# TODO: add progress bars
 
 
 def parse_args():
@@ -23,19 +23,12 @@ def parse_args():
     If no token is specified prompt for it.
     :return: Returns the parsed CLI datastructures.
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Given a username - go through all orgs in the orglist.ini file and see "
         "what they need to be removed from"
     )
     parser.add_argument("username", help="User to remove")
     parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     parser.add_argument(
         "--orgfile",
         help='use an ini file with the "orgs" '
@@ -55,9 +48,6 @@ def parse_args():
     args = parser.parse_args()
     if args.orgs == [] and args.orgfile is None:
         raise Exception("You must specify either an org or an orgfile")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/org_repos.py
+++ b/org_repos.py
@@ -5,9 +5,6 @@ Used primarily as input to repo related scripts - allowing action on all or a su
 (poor person's rate limiting)
 """
 
-import argparse
-from getpass import getpass
-
 from github3 import login
 
 from github_scripts import utils
@@ -20,15 +17,8 @@ def parse_args():
     :return: Returns the parsed CLI datastructures.
     """
 
-    parser = argparse.ArgumentParser(description="Gets a list of Repos for an Org.")
+    parser = utils.GH_ArgParser(description="Gets a list of Repos for an Org.")
     parser.add_argument("org", help="The GH org to query", action="store", type=str)
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     parser.add_argument(
         "--without-org",
         help="Include the org in the name, 'org/repo-name'",
@@ -49,9 +39,6 @@ def parse_args():
         choices=["public", "private", "all"],
     )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/org_samlreport.py
+++ b/org_samlreport.py
@@ -10,10 +10,8 @@ search for OutsideCollaboratorIterator on this page:
 https://github.com/mozilla/github-org-scripts/blob/main/notebooks/UserSearchPy3.ipynb
 """
 
-import argparse
 import datetime
 import sys
-from getpass import getpass
 
 import requests
 from github3 import login
@@ -25,7 +23,7 @@ def parse_arguments():
     """
     Look at the first arg and handoff to the arg parser for that specific
     """
-    parser = argparse.ArgumentParser(description="Get SAML account mappings out of a GitHub org")
+    parser = utils.GH_ArgParser(description="Get SAML account mappings out of a GitHub org")
     parser.add_argument("org", type=str, help="The org to work on", action="store")
     parser.add_argument(
         "--url",
@@ -35,19 +33,9 @@ def parse_arguments():
         default="https://api.github.com/graphql",
     )
     parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
-    parser.add_argument(
         "-f", type=str, help="File to store CSV to", action="store", default=None, dest="output"
     )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 
@@ -142,8 +130,6 @@ def main():
     Query github org and return the mapping of the SAML to GH login
     """
     args = parse_arguments()
-    if args.token is None:
-        args.token = getpass("Enter your PAT: ")
 
     headers = {"content-type": "application/json", "Authorization": "Bearer " + args.token}
 

--- a/org_secret_alerts.py
+++ b/org_secret_alerts.py
@@ -3,9 +3,6 @@
 Script to pull out any existing security alerts
 """
 
-import argparse
-from getpass import getpass
-
 import requests
 
 from github_scripts import utils
@@ -15,22 +12,12 @@ def parse_arguments():
     """
     Look at the first arg and handoff to the arg parser for that specific
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="examine org for open security alerts from secret scanning, outputting csv data to pursue the alerts"
     )
     parser.add_argument("org", type=str, help="The org that the repos are in")
 
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/org_teams.py
+++ b/org_teams.py
@@ -3,9 +3,6 @@
 Script to a list of teams in an org, with user lists
 """
 
-import argparse
-from getpass import getpass
-
 from github3 import login
 
 from github_scripts import utils
@@ -18,17 +15,10 @@ def parse_args():
     :return: Returns the parsed CLI datastructures.
     """
 
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Gets a list of teams and their users for an Org.  Users with '*' are maintainers of the team, reports using the team-slug"
     )
     parser.add_argument("org", help="The GH org to query", action="store", type=str)
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
 
     parser.add_argument(
         "--team",
@@ -42,9 +32,6 @@ def parse_args():
     )
 
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
 
     return args
 

--- a/repo_active_users.py
+++ b/repo_active_users.py
@@ -5,10 +5,8 @@ Given a list of repos, and a timefame, check out the reop
 and return the list of unique users in that repo
 """
 
-import argparse
 import sys
 import tempfile
-from getpass import getpass
 
 from git import Repo
 
@@ -22,7 +20,7 @@ def parse_args():
     Timeframe to look over.  Default to 30 days.
     """
 
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Gets a list of active users for a list of repos"
         "Also checks wiki for activity, and can be told to check for issues activity."
     )
@@ -44,18 +42,8 @@ def parse_args():
         help="Use the author rather than committer email, if you're concerned about people with permissions, committer is what you want",
         action="store_true",
     )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/repo_activity.py
+++ b/repo_activity.py
@@ -6,11 +6,9 @@ Also look to see if there's a wiki, and check for activity there.
 Used to help determination for archiving/moving repos that aren't active
 """
 
-import argparse
 import sys
 import tempfile
 from datetime import datetime
-from getpass import getpass
 
 import pytz
 from git import Repo
@@ -36,7 +34,7 @@ def parse_args():
     :return: Returns the parsed CLI datastructures.
     """
 
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Gets a latest activity for a repo or list of repos.  "
         "Also checks wiki for activity, and can be told to check for issues activity."
     )
@@ -45,13 +43,6 @@ def parse_args():
         help="list of repos to examine - or use --file for file base input",
         action="store",
         nargs="*",
-    )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
     )
     parser.add_argument(
         "--issues",
@@ -70,9 +61,6 @@ def parse_args():
     args = parser.parse_args()
     if args.repos is None and args.file is None:
         raise Exception("Must have either a list of repos, OR a file to read repos from")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/repo_add_perms.py
+++ b/repo_add_perms.py
@@ -4,9 +4,7 @@ Script to add user or team to a list of repos
 If adding a user, if the user is a member, adds the member, else invites as an OC.
 """
 
-import argparse
 import json
-from getpass import getpass
 from logging import exception
 
 import requests
@@ -19,7 +17,7 @@ def parse_arguments():
     """
     Parse the command line
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="invite member or team to specified repos at specified level. If adding a user, if the user is a member, adds the member, else invites as an OC."
     )
     parser.add_argument(
@@ -38,18 +36,7 @@ def parse_arguments():
         help="API host to connect to - default api.github.com",
         default="api.github.com",
     )
-
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/repo_archiver.py
+++ b/repo_archiver.py
@@ -8,9 +8,7 @@ prepends "DEPRECATED - " to the description
 Archives the repo
 """
 
-import argparse
 import sys
-from getpass import getpass
 
 import getch
 from github3 import exceptions as gh_exceptions
@@ -28,22 +26,12 @@ def parse_args():
     If no token is specified prompt for it.
     :return: Returns the parsed CLI datastructures.
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Archive the specified repo, labelling and then closing out issues and PRs, "
         "per GitHub best practices.  Closed issues/PRs, and description/topic changes "
         "can be completely reversed using the repo_unarchiver script."
     )
     parser.add_argument("repos", help="owner/repo to archive", nargs="*", action="store")
-    parser.add_argument(
-        "--token", help="PAT to access github.  Needs Write access to the repos", action="store"
-    )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
     parser.add_argument(
         "--inactive",
         help="Change the 'abandoned' and 'deprecated' wording to 'inactive'",
@@ -78,9 +66,6 @@ def parse_args():
         raise Exception("Must have either a list of repos, OR a file to read repos from")
     if args.custom is not None and len(args.custom) > MAX_CUSTOM_LENGTH:
         raise Exception(f"Custom string must be less than {MAX_CUSTOM_LENGTH} characters")
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/repo_close_issues.py
+++ b/repo_close_issues.py
@@ -5,9 +5,7 @@ PR's are "special" issues - flag for including those if desired.
 defaults to Dry run - will print out everything that will happen without DOING anything.
 """
 
-import argparse
 import time
-from getpass import getpass
 
 from github3 import exceptions as gh_exceptions
 from github3 import login
@@ -21,7 +19,7 @@ def parse_args():
     If no token is specified prompt for it.
     :return: Returns the parsed CLI datastructures.
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Close issues associated with the specified repo.  Do not close PRs unless specified, and only do things if specified"
     )
     parser.add_argument("org", help="Org/owner name")
@@ -32,25 +30,12 @@ def parse_args():
     parser.add_argument("--comment", help="A comment to close the issue with")
     parser.add_argument("--doit", help="Actually close things", action="store_true")
     parser.add_argument(
-        "--token", help="PAT to access github.  Needs Write access to the repos", action="store"
-    )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use",
-    )
-    parser.add_argument(
         "--delay",
         default=2,
         type=float,
         help="seconds between close requests, to avoid secondary rate limits > 1",
     )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 

--- a/repo_unarchiver.py
+++ b/repo_unarchiver.py
@@ -16,9 +16,7 @@ https://docs.github.com/en/rest/reference/repos#update-a-repository
 Note: You cannot unarchive repositories through the API.
 """
 
-import argparse
 import sys
-from getpass import getpass
 
 from github3 import exceptions as gh_exceptions
 from github3 import login
@@ -34,21 +32,11 @@ def parse_args():
     If no token is specified prompt for it.
     :return: Returns the parsed CLI datastructures.
     """
-    parser = argparse.ArgumentParser(
+    parser = utils.GH_ArgParser(
         description="Reverse archival closing of issues of the specified repo, Note, repo "
         "MUST be manually unarchived before this script"
     )
     parser.add_argument("repo", help="owner/repo to unarchive", action="store")
-    parser.add_argument(
-        "--token", help="PAT to access github.  Needs Write access to the repos", action="store"
-    )
-    parser.add_argument(
-        "--pat-key",
-        default="admin",
-        action="store",
-        dest="patkey",
-        help="key in .gh_pat.toml of the PAT to use, default: 'admin'",
-    )
     parser.add_argument(
         "-q",
         help="DO NOT print, or request confirmations",
@@ -57,9 +45,6 @@ def parse_args():
         default=False,
     )
     args = parser.parse_args()
-    args.token = utils.get_pat_from_file(args.patkey)
-    if args.token is None:
-        args.token = getpass("Please enter your GitHub token: ")
     return args
 
 


### PR DESCRIPTION
Created `utils.GH_ArgParser` with default token/patfile handling, and then revamped the scripts to use that instead of the scattershot "some do toml files, some do token, some do both, etc"  