### PR TITLE
Add better handling between old-spinner and new-progress

### DIFF
--- a/org_dependency_search.py
+++ b/org_dependency_search.py
@@ -183,6 +183,7 @@ def main():
             utils.check_rate_remain(gh_sess)
             if args.unarchived and repo.archived:
                 continue
+            utils.check_rate_remain(gh_sess=gh_sess, bar=bar)
             dependency_dict = run_query(org_obj.login, repo.name, headers, args.url)
 
             for cursor in dependency_dict:


### PR DESCRIPTION
Make the rate-remain code handle progress bars rather than assume oldstyle spinner.