### PR TITLE
Updating workflow to remove nodejs deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Cache things
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ${{ runner.os }}
         path: |
           ~/.cache
           ~/.poetry
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies


### PR DESCRIPTION
The workflows items in the actions have been giving deprecation notices for nodejs and some others for awhile.  Updating to get past the nodejs warnings.  (and appears to have cleared the other warnings as a side effect.)