### PR TITLE
Updating org_add_user to handle errors more expressively and use args…

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,19 +135,17 @@ optional arguments:
 
 ## `org_add_user.py`
 ```
-usage: org_add_user.py [-h] [--pat-key PATKEY] [--token TOKEN] [--teams TEAMS [TEAMS ...]] [--owner] org username
+usage: org_add_user.py [-h] [--pat-key PATKEY] [--token TOKEN] [--org ORG] [--user USERNAME] [--teams TEAMS [TEAMS ...]] [--owner]
 
 Give a username, an org, and a team list and add the user to the org. NOTE: if the org is SAML'd you'll probably need to provision
 the user in your IdP system(s)
-
-positional arguments:
-  org                   The org to work with
-  username              GH user ID to add
 
 options:
   -h, --help            show this help message and exit
   --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
   --token TOKEN         use this PAT to access resources
+  --org ORG             The org to work with
+  --user USERNAME       GH user ID to add
   --teams TEAMS [TEAMS ...]
                         list of team slugs
   --owner               Should they be an owner

--- a/org_add_user.py
+++ b/org_add_user.py
@@ -4,6 +4,8 @@ Script for adding a user to an org
 Given a username an org, and a list of teams, send an invite to that user for the org/team
 """
 
+import logging
+
 from github3 import exceptions as gh_exceptions
 from github3 import login
 
@@ -21,8 +23,8 @@ def parse_args():
     parser = utils.GH_ArgParser(
         description="Give a username, an org, and a team list and add the user to the org.  NOTE: if the org is SAML'd you'll probably need to provision the user in your IdP system(s)"
     )
-    parser.add_argument("org", type=str, help="The org to work with", action="store")
-    parser.add_argument("username", help="GH user ID to add")
+    parser.add_argument("--org", type=str, help="The org to work with", action="store")
+    parser.add_argument("--user", help="GH user ID to add", dest="username")
     parser.add_argument("--teams", help="list of team slugs", nargs="+")
     parser.add_argument("--owner", help="Should they be an owner", action="store_true")
     args = parser.parse_args()
@@ -37,12 +39,12 @@ def main():
         org = gh_sess.organization(args.org)
     except gh_exceptions.NotFoundError:
         print(f"Organization {args.org} is not found")
-        exit()
+        exit(1)
     try:
         user_id = gh_sess.user(args.username).id
     except gh_exceptions.NotFoundError:
         print(f"User {args.username} is not found")
-        exit()
+        exit(1)
     teamlist = []
     if args.teams is not None:
         try:
@@ -50,7 +52,7 @@ def main():
                 teamlist.append(org.team_by_name(teamslug).id)
         except gh_exceptions.NotFoundError:
             print("Teams not resolving - please verify the team-slug")
-            exit()
+            exit(1)
     # For some reason the module uses different terms for the member privilege if you're not adding a team
     # and also (later in the code) you'll see that it uses a different method to invite the teamless.
     if args.owner:
@@ -62,11 +64,19 @@ def main():
 
     try:
         if args.teams is not None:
+            # github3 has a problem where it detects the 201 as a concern rather than SUCCESS - and they've
+            # not been responsive to requests to look at it.
+            oldlevel = logging.getLogger("github3").level
+            logging.getLogger("github3").setLevel(logging.ERROR)
             org.invite(team_ids=teamlist, invitee_id=user_id, role=priv)
+            logging.getLogger("github3").setLevel(oldlevel)
         else:
             org.add_or_update_membership(username=args.username, role=priv)
     except Exception as error:
         print(f"An exception on creation occurred: {error}")
+        exit(1)
+    else:
+        print(f"Invited user {args.username} to org {args.org}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
… slightly differently to help with scripting

Specifically --user and --org added so that the potentially multi term --teams field can appear anywhere and not just the end.  

Also, added error and success messages with exits.  