### PR TITLE
Removing orgini references as unused - closes #12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ optional arguments:
 ```
 
 ## `gh_dependency_search.py`
+NOTE - This relies on API searches, which GitHub is NOT advancing - you'll get better results using the WEBUI search
 ```
-usage: gh_dependency_search.py [-h] [--pat-key PATKEY] [--token TOKEN] --package PACKAGE [--orgini] [-v] [-f] [-t TIME]
+usage: gh_dependency_search.py [-h] [--pat-key PATKEY] [--token TOKEN] --package PACKAGE [-v] [-f] [-t TIME]
                                [--language {Python,Javascript}]
                                [orgs ...]
 
@@ -50,7 +51,6 @@ optional arguments:
   --pat-key PATKEY      key in .gh_pat.toml of the PAT to use
   --token TOKEN         use this PAT to access resources
   --package PACKAGE     The package to search for.
-  --orgini              use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
   -v                    Verbose - Print out that we're waiting for rate limit reasons
   -f                    Print out file level responses rather than repo level
   -t TIME               Time to sleep between searches, in seconds, should be 10s or more
@@ -59,8 +59,9 @@ optional arguments:
 ```
 
 ## `gh_file_search.py`
+NOTE - This relies on API searches, which GitHub is NOT advancing - you'll get better results using the WEBUI search
 ```
-usage: gh_file_search.py [-h] [--pat-key PATKEY] [--token TOKEN] --query QUERY [--note-archive] [--orgini] [-v] [-f] [-t TIME]
+usage: gh_file_search.py [-h] [--pat-key PATKEY] [--token TOKEN] --query QUERY [--note-archive] [-v] [-f] [-t TIME]
                          [orgs ...]
 
 Get file search results for an org, returning repo list. e.g. if you want 'org:<ORGNAME> filename:<FILENAME> <CONTENTS>', then you
@@ -77,7 +78,6 @@ optional arguments:
   --query QUERY     The query to run, without orgs
   --note-archive    if specified, will add archival status of the repo to the output, this will slow things down and use more API
                     calls
-  --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
   -v                Verbose - Print out that we're waiting for rate limit reasons
   -f                Print out file level responses rather than repo level
   -t TIME           Time to sleep between searches, in seconds, should be 10s or more
@@ -85,12 +85,12 @@ optional arguments:
 
 ## `gh_org_licenses.py`
 ```
-usage: gh_org_licenses.py [-h] [--pat-key PATKEY] [--token TOKEN] [--pending] [--verbose] [--orgini] [orgs ...]
+usage: gh_org_licenses.py [-h] [--pat-key PATKEY] [--token TOKEN] [--pending] [--verbose] orgs [orgs ...]
 
 Provided a list of orgs, output how many GHE licenses are required.
 
 positional arguments:
-  orgs              The org to work on
+  orgs              The orgs to work on
 
 options:
   -h, --help        show this help message and exit
@@ -98,7 +98,6 @@ options:
   --token TOKEN     use this PAT to access resources
   --pending         Include Pending requests?
   --verbose         Output lists of members and ocs that are using license
-  --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
   ```
 
 ## `gh_pat_owner.py`
@@ -118,7 +117,7 @@ optional arguments:
 
 ## `gh_user_moderation.py`
 ```
-usage: gh_user_moderation.py [-h] [--pat-key PATKEY] [--token TOKEN] [--block] [--orgini] username [orgs ...]
+usage: gh_user_moderation.py [-h] [--pat-key PATKEY] [--token TOKEN] [--block] username orgs [orgs ...]
 
 Look at orgs, and either block or unblock the specified username
 
@@ -126,12 +125,11 @@ positional arguments:
   username          The GH user name to block/unblock
   orgs              The org to work on
 
-optional arguments:
+options:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
   --token TOKEN     use this PAT to access resources
   --block           should we block the user - default is unblock
-  --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
 ```
 
 ## `org_add_user.py`
@@ -155,7 +153,6 @@ options:
 ## `org_audit_licensefile.py`
 ```
 usage: org_audit_licensefile.py [-h] [--pat-key PATKEY] [--token TOKEN] [--archived] [--type {public,private,all}] [--include-URL]
-                                [--orgini]
                                 [orgs ...]
 
 given the org, look through all repos of type, and archive status and report on github detected licenses.
@@ -171,7 +168,6 @@ optional arguments:
   --type {public,private,all}
                         Type of repo: private, public, all (Default).
   --include-URL         Include the URL to the repo as a help for people analyzing things
-  --orgini              use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
 ```
 
 ## `org_comms_team.py`
@@ -196,6 +192,7 @@ optional arguments:
 ```
 
 ## `org_dependency_search.py`
+NOTE - This relies on API searches, which GitHub is NOT advancing - you'll get better results using the WEBUI search
 ```
 usage: org_dependency_search.py [-h] [--pat-key PATKEY] [--token TOKEN] [--archived] [--url URL] org package
 
@@ -251,7 +248,7 @@ options:
 
 ## `org_owners.py`
 ```
-usage: org_owners.py [-h] [--pat-key PATKEY] [--token TOKEN] [--orgini] [orgs ...]
+usage: org_owners.py [-h] [--pat-key PATKEY] [--token TOKEN] [orgs ...]
 
 Look at orgs, and get the list of owners
 
@@ -262,7 +259,6 @@ optional arguments:
   -h, --help        show this help message and exit
   --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
   --token TOKEN     use this PAT to access resources
-  --orgini          use "orglist.ini" with the "orgs" entry with a csv list of all orgs to check
 ```
 
 ## `org_remove_user.py`
@@ -578,13 +574,6 @@ options:
 ```
 
 # Supporting files
-
-## `orglist.ini`
-Used for scripts using lists of orgs, (currently only gh_file_search.py)
-```
-[GITHUB]
-orgs = org1,org2,org3
-```
 
 ## `.gh_pat.toml`
 Used to store PAT files - used by several of the scripts.

--- a/gh_dependency_search.py
+++ b/gh_dependency_search.py
@@ -29,13 +29,7 @@ def parse_arguments():
     parser.add_argument(
         "--package", type=str, help="The package to search for.", action="store", required=True
     )
-    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
-    parser.add_argument(
-        "--orgini",
-        help='use "orglist.ini" with the "orgs" ' "entry with a csv list of all orgs to check",
-        action="store_const",
-        const="orglist.ini",
-    )
+    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="+")
     parser.add_argument(
         "-v",
         dest="verbose",
@@ -63,8 +57,6 @@ def parse_arguments():
         help=f"Language to search for dependency, default is {language_default}",
     )
     args = parser.parse_args()
-    if args.orgs == [] and args.orgini is None:
-        raise Exception("You must specify either an org or an orgini")
     return args
 
 
@@ -77,7 +69,7 @@ def main():
 
     # just call gh_file_search.py with the defaults
     for file in language_files[args.language]:
-        new_query = f"filename:{file} {args.package}"
+        new_query = f"filename:{file} {args.package}"  # noqa E231
         # rudely inject the query option and archive status
         args.query = new_query
         args.note_archive = True

--- a/gh_file_search.py
+++ b/gh_file_search.py
@@ -3,7 +3,6 @@
 Script to perform a search of supplied orgs, returning the repo list that return positives
 """
 
-import configparser
 import sys
 from time import sleep
 
@@ -35,13 +34,7 @@ def parse_arguments():
         action="store_true",
         dest="note_archive",
     )
-    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
-    parser.add_argument(
-        "--orgini",
-        help='use "orglist.ini" with the "orgs" ' "entry with a csv list of all orgs to check",
-        action="store_const",
-        const="orglist.ini",
-    )
+    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="+")
     parser.add_argument(
         "-v",
         dest="verbose",
@@ -63,8 +56,6 @@ def parse_arguments():
         help="Time to sleep between searches, in seconds, should be 10s or more",
     )
     args = parser.parse_args()
-    if args.orgs == [] and args.orgini is None:
-        raise SystemExit("You must specify either an org or an orgini")
     return args
 
 
@@ -79,13 +70,7 @@ def main():
 
 def do_search(args):
     # Read in the config if there is one
-    orglist = []
-    if args.orgini is not None:
-        config = configparser.ConfigParser()
-        config.read(args.orgini)
-        orglist = config["GITHUB"]["orgs"].split(",")
-    else:
-        orglist = args.orgs
+    orglist = args.orgs
 
     gh_sess = login(token=args.token)
     if not gh_sess:

--- a/gh_user_moderation.py
+++ b/gh_user_moderation.py
@@ -3,8 +3,6 @@
 Script to manually poke the blocks/unblocks for orgs.
 """
 
-import configparser
-
 import requests
 
 from github_scripts import utils
@@ -21,16 +19,8 @@ def parse_arguments():
     parser.add_argument(
         "--block", help="should we block the user - default is unblock", action="store_true"
     )
-    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
-    parser.add_argument(
-        "--orgini",
-        help='use "orglist.ini" with the "orgs" ' "entry with a csv list of all orgs to check",
-        action="store_const",
-        const="orglist.ini",
-    )
+    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="+")
     args = parser.parse_args()
-    if args.orgs == [] and args.orgini is None:
-        raise Exception("You must specify either an org or an orgini")
     return args
 
 
@@ -71,13 +61,7 @@ def main():
     """
     args = parse_arguments()
     # Read in the config if there is one
-    orglist = []
-    if args.orgini is not None:
-        config = configparser.ConfigParser()
-        config.read(args.orgini)
-        orglist = config["GITHUB"]["orgs"].split(",")
-    else:
-        orglist = args.orgs
+    orglist = args.orgs
 
     for org in orglist:
         if args.block:

--- a/org_audit_licensefile.py
+++ b/org_audit_licensefile.py
@@ -3,7 +3,6 @@
 Script to perform a search of supplied orgs, and return the list of detected repo licenses.
 """
 
-import configparser
 import sys
 from datetime import datetime
 
@@ -21,7 +20,7 @@ def parse_arguments():
     parser = utils.GH_ArgParser(
         description="given the org, look through all repos of type, and archive status and report on github detected licenses."
     )
-    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="*")
+    parser.add_argument("orgs", type=str, help="The org to work on", action="store", nargs="+")
     parser.add_argument(
         "--archived",
         help="Include archived repos.  Default is unarchived only.",
@@ -40,15 +39,7 @@ def parse_arguments():
         action="store_true",
         help="Include the URL to the repo as a help for people analyzing things",
     )
-    parser.add_argument(
-        "--orgini",
-        help='use "orglist.ini" with the "orgs" ' "entry with a csv list of all orgs to check",
-        action="store_const",
-        const="orglist.ini",
-    )
     args = parser.parse_args()
-    if args.orgs == [] and args.orgini is None:
-        raise Exception("You must specify either an org or an orgini")
     return args
 
 
@@ -71,13 +62,7 @@ def main():
     args = parse_arguments()
     resultlist = []
     # Read in the config if there is one
-    orglist = []
-    if args.orgini is not None:
-        config = configparser.ConfigParser()
-        config.read(args.orgini)
-        orglist = config["GITHUB"]["orgs"].split(",")
-    else:
-        orglist = args.orgs
+    orglist = args.orgs
 
     gh_sess = login(token=args.token)
     linedict = {


### PR DESCRIPTION
Orgini was envisioned as a quick way to give a list of orgs to the scripts. Over the years, it's just gone unused, and hasn't been added to most of the current scripts, and it's not missed.

org_owners.py
gh_dependency_search.py
org_audit_licensefile.py
gh_file_search.py
gh_org_licenses.py
gh_user_moderation.py
README.md

Have all had orgini removed, and the org list made required.