### PR TITLE
Adding org_list.py to list all orgs the running user belongs to

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ options:
                         Type of repo, all (default), public, private
 ```
 
+## `org_list.py`
+```
+usage: org_list.py [-h] [--pat-key PATKEY] [--token TOKEN]
+
+Gets a list of the organizations that the user belongs to. Useful as input to scripts that take a list of orgs. Note if you have personal orgs, this will be included.
+
+options:
+  -h, --help        show this help message and exit
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
+```
+
 ## `org_owners.py`
 ```
 usage: org_owners.py [-h] [--pat-key PATKEY] [--token TOKEN] [orgs ...]

--- a/org_list.py
+++ b/org_list.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""
+Script to list the organizations that the runner belongs to.
+"""
+
+from github3 import login
+
+from github_scripts import utils
+
+
+def parse_args():
+    """
+    Parse the command line.
+    Detects if no PAT is given, asks for it.
+    :return: Returns the parsed CLI datastructures.
+    """
+
+    parser = utils.GH_ArgParser(
+        description="Gets a list of the organizations that the user belongs to.  Useful as input to scripts that take a list of orgs.  Note if you have personal orgs, this will be included."
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    """Get the list of orgs"""
+    args = parse_args()
+
+    gh_sess = login(token=args.token)
+    for org in gh_sess.organizations():
+        print(org.login)
+
+
+if __name__ == "__main__":
+    main()

--- a/orglist.ini-EXAMPLE
+++ b/orglist.ini-EXAMPLE
@@ -1,2 +1,0 @@
-[GITHUB]
-orgs = org1,org2,org3


### PR DESCRIPTION
This is useful for the cases where you want the list of all orgs so you can run OTHER scripts here against them.  