### PR TITLE
Adding clarification for scripts that fail when PAT's aren't authorized

### DIFF
--- a/org_audit_licensefile.py
+++ b/org_audit_licensefile.py
@@ -108,6 +108,9 @@ def main():
                             "file": "",
                             "type": "NO LICENSE DETECTED",
                         }
+                    except gh_exceptions.ForbiddenError as err:
+                        print(err)
+                        sys.exit()
                     else:
                         linedict = {
                             "org": f"{repo.owner}",

--- a/org_audit_licensefile.py
+++ b/org_audit_licensefile.py
@@ -109,7 +109,7 @@ def main():
                             "type": "NO LICENSE DETECTED",
                         }
                     except gh_exceptions.ForbiddenError as err:
-                        print(err)
+                        print(f"Error: {err}")
                         sys.exit()
                     else:
                         linedict = {

--- a/org_dependency_search.py
+++ b/org_dependency_search.py
@@ -136,6 +136,8 @@ def run_query(org, repo, headers, url):
             raise Exception(
                 f"Query failed to run by returning code of" f" {request.status_code}. {query}"
             )
+        if "errors" in jsonified.keys():
+            raise Exception(f"{jsonified['errors'][0]['message']}")
         try:
             has_next_page = next_page(jsonified)
             cursor = get_cursor(jsonified)

--- a/org_dependency_search.py
+++ b/org_dependency_search.py
@@ -137,7 +137,7 @@ def run_query(org, repo, headers, url):
                 f"Query failed to run by returning code of" f" {request.status_code}. {query}"
             )
         if "errors" in jsonified.keys():
-            raise Exception(f"{jsonified['errors'][0]['message']}")
+            raise Exception(f"Error: {jsonified['errors'][0]['message']}")
         try:
             has_next_page = next_page(jsonified)
             cursor = get_cursor(jsonified)

--- a/org_repo_perms.py
+++ b/org_repo_perms.py
@@ -162,11 +162,14 @@ def main():
                 resultdict[repo] = {}
                 query = make_query(args.org, repo, cursor)
                 result = requests.post(url=args.url, json={"query": query}, headers=headers)
+                result_json = result.json()
                 if result.status_code != 200:
                     raise Exception(
                         f"Query failed to run by returning code of"
                         f" {result.status_code}. {query}"
                     )
+                if "errors" in result_json.keys():
+                    raise Exception(f"{result_json['errors'][0]['message']}")
                 resultdict[repo].update(
                     parse_user_data(
                         result.json()["data"]["repository"]["collaborators"]["edges"], args.all

--- a/org_repo_perms.py
+++ b/org_repo_perms.py
@@ -169,7 +169,7 @@ def main():
                         f" {result.status_code}. {query}"
                     )
                 if "errors" in result_json.keys():
-                    raise Exception(f"{result_json['errors'][0]['message']}")
+                    raise Exception(f"Error: {result_json['errors'][0]['message']}")
                 resultdict[repo].update(
                     parse_user_data(
                         result.json()["data"]["repository"]["collaborators"]["edges"], args.all

--- a/poetry.lock
+++ b/poetry.lock
@@ -688,19 +688,18 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "setuptools"
-version = "67.6.1"
+version = "70.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
-    {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
+    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
+    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"


### PR DESCRIPTION
Not all scripts fail on bad pat - and several fail with a proper error message.  Adding exception handling to those that failed in non-obvious ways.  

org_audit_licensefile.py
org_dependency_search.py
org_repo_perms.py

This is usually a thing with the scripts that are poking the graphql endpoints.  