### PR TITLE
Adding enterprise_copilot_stats.py to help track copilot usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Starts with:
 * "org_" - limited to single orgs, occasionally multiple (e.g. "list all repos in ORG")
 * "repo_" limited to just repos. (e.g. "Archive this repo")
 
+
+## `enterprise_copilot_stats.py`
+```
+usage: enterprise_copilot_stats.py [-h] [--pat-key PATKEY] [--token TOKEN] [--url URL] enterprise
+
+Get top level copilot stats, including active user counts, and suggestions/acceptances usage
+
+positional arguments:
+  enterprise        The enterprise to work on
+
+options:
+  -h, --help        show this help message and exit
+  --pat-key PATKEY  key in .gh_pat.toml of the PAT to use
+  --token TOKEN     use this PAT to access resources
+  --url URL         the API hostname - defaults to api.github.com
+```
+
 ## `enterprise_org_list.py`
 ```
 usage: enterprise_org_list.py [-h] [--pat-key PATKEY] [--token TOKEN] [--url URL] enterprise

--- a/enterprise_copilot_stats.py
+++ b/enterprise_copilot_stats.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""
+Script to interpret a stream of json as copilot metrics.
+https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics?apiVersion=2022-11-28#get-copilot-metrics-for-an-enterprise
+"""
+
+import requests
+
+from github_scripts import utils
+
+
+def parse_arguments():
+    """
+    Look at the first arg and handoff to the arg parser for that specific
+    """
+    parser = utils.GH_ArgParser(
+        description="Get top level copilot stats, including active user counts, and suggestions/acceptances usage"
+    )
+    parser.add_argument("enterprise", type=str, help="The enterprise to work on", action="store")
+    parser.add_argument(
+        "--url",
+        type=str,
+        help="the API hostname - defaults to api.github.com",
+        action="store",
+        default="api.github.com",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_arguments()
+    headers = {"content-type": "application/json", "Authorization": "Bearer " + args.token}
+
+    query = f"https://{args.url}/enterprises/{args.enterprise}/copilot/metrics"
+
+    response = requests.get(url=query, headers=headers)
+
+    if response.status_code != 200:
+        print(f"Response code of {response.status_code}")
+        exit()
+    results = {}
+    # a dict of dicts, keyed by day, with sub lists for active users, engaged users (?) and suggestions vs accepteds.
+    # There's no indication in the API docs over what constitutes an active vs. engaged user.
+    jsondata = response.json()
+    # print(jsondata[0]["date"])
+    for day in jsondata:
+        results[day["date"]] = {
+            "active": day["total_active_users"],
+            "engaged": day["total_engaged_users"],
+        }
+        # print(day["copilot_ide_code_completions"]["editors"])
+        suggest = 0
+        accept = 0
+        # Things in this metric rather than the old "here's the total" require you to add things up
+        # Things are broken down by editor, model, and language.
+        # Right now, we just care about TOTAL usage numbers.
+        # But leaving the loops in place individually in case we want to add filtering for specifics
+        for editors in day["copilot_ide_code_completions"]["editors"]:
+            for models in editors["models"]:
+                for languages in models["languages"]:
+                    # Note, there's two different fields, unexplained - "code accepted" and "code acceptances"
+                    # decided to go with acceptances, as that looks more like the previous data "total_acceptances_count"
+                    accept += languages["total_code_acceptances"]
+                    suggest += languages["total_code_suggestions"]
+                    # accept += languages["total_code_lines_accepted"]
+                    # suggest += languages["total_code_lines_suggested"]
+
+        results[day["date"]]["acceptances"] = accept
+        results[day["date"]]["suggestions"] = suggest
+    print("Date, Total Suggestions, Total Acceptances, Active users")
+    for day in results:
+        print(
+            f'{day},{results[day]["suggestions"]},{results[day]["acceptances"]},{results[day]["active"]}'
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Script to utilize the https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics?apiVersion=2022-11-28#get-copilot-metrics-for-an-enterprise APIs - which replaced the much simpler https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage?apiVersion=2022-11-28 API

The old version could be easily queried for top level stats with a jq script - this one needs a little more structure.  Reports "Active Users" (there's an "Engaged user" as well, but with no indication as to the difference.) and the code suggestions and accepted suggestions per day.