### PR TITLE
Update limit_remain in all iterations of the check_rate_remain loop

### DIFF
--- a/github_scripts/utils.py
+++ b/github_scripts/utils.py
@@ -131,10 +131,10 @@ def check_rate_remain(gh_sess, loopsize=100, update=True, bar=None, search=False
                 print("API timeout reset, continuing", file=sys.stderr)
             else:
                 bar.text = oldtitle
-            if search:
-                limit_remain = gh_sess.rate_limit()["resources"]["search"]["remaining"]
-            else:
-                limit_remain = gh_sess.rate_limit()["resources"]["core"]["remaining"]
+        if search:
+            limit_remain = gh_sess.rate_limit()["resources"]["search"]["remaining"]
+        else:
+            limit_remain = gh_sess.rate_limit()["resources"]["core"]["remaining"]
 
 
 def check_graphql_rate_remain(


### PR DESCRIPTION
The `limit_remain` number was only updated IF `update`.  While `update is default-true, the limit_remain value should be updated on each loop / in all cases.